### PR TITLE
Remove height from go back to movies button in Favourites container

### DIFF
--- a/src/Components/FavouritesContainer/FavouritesContainer.scss
+++ b/src/Components/FavouritesContainer/FavouritesContainer.scss
@@ -33,7 +33,6 @@ $hover-color: gold;
 
 .back_to_movies__btn {
     border-radius: 10px;
-    height: 55px;
     font-size: 2em;
     margin: 5px;
     padding: 13px;


### PR DESCRIPTION
- removed height from back to movies button as it was not keeping the words in the centre.